### PR TITLE
Fix UE 5.8 compile compatibility

### DIFF
--- a/Plugins/NanoGS/Source/NanoGS/Private/GaussianSplatAsset.cpp
+++ b/Plugins/NanoGS/Source/NanoGS/Private/GaussianSplatAsset.cpp
@@ -441,7 +441,9 @@ void UGaussianSplatAsset::CreateColorTextureFromData()
 	ColorTexture->AddressY = TA_Clamp;
 	ColorTexture->NeverStream = true;
 	ColorTexture->LODGroup = TEXTUREGROUP_Pixels2D;
+#if WITH_EDITORONLY_DATA
 	ColorTexture->MipGenSettings = TMGS_NoMipmaps;
+#endif
 
 	// Create mip 0
 	FTexture2DMipMap* Mip = new FTexture2DMipMap();

--- a/Plugins/NanoGS/Source/NanoGS/Private/GaussianSplatSceneProxy.cpp
+++ b/Plugins/NanoGS/Source/NanoGS/Private/GaussianSplatSceneProxy.cpp
@@ -12,6 +12,8 @@
 #include "SceneManagement.h"
 #include "DynamicMeshBuilder.h"
 #include "Materials/Material.h"
+#include "MaterialDomain.h"
+#include "TextureResource.h"
 #include "EngineUtils.h"
 
 //////////////////////////////////////////////////////////////////////////

--- a/Plugins/NanoGS/Source/NanoGS/Public/GaussianSplatAsset.h
+++ b/Plugins/NanoGS/Source/NanoGS/Public/GaussianSplatAsset.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Engine/Texture2D.h"
 #include "UObject/ObjectMacros.h"
 #include "Serialization/BulkData.h"
 #include "GaussianDataTypes.h"

--- a/Plugins/NanoGS/Source/NanoGSEditor/Private/GaussianSplatAssetFactory.cpp
+++ b/Plugins/NanoGS/Source/NanoGSEditor/Private/GaussianSplatAssetFactory.cpp
@@ -5,6 +5,7 @@
 #include "PLYFileReader.h"
 #include "EditorFramework/AssetImportData.h"
 #include "Misc/FeedbackContext.h"
+#include "Misc/Paths.h"
 #include "Misc/ScopedSlowTask.h"
 
 UGaussianSplatAssetFactory::UGaussianSplatAssetFactory()

--- a/Plugins/NanoGS/Source/NanoGSEditor/Private/GaussianSplatAssetTypeActions.cpp
+++ b/Plugins/NanoGS/Source/NanoGSEditor/Private/GaussianSplatAssetTypeActions.cpp
@@ -5,6 +5,7 @@
 #include "EditorReimportHandler.h"
 #include "ToolMenuSection.h"
 #include "Framework/MultiBox/MultiBoxBuilder.h"
+#include "Misc/MessageDialog.h"
 #include "Misc/Paths.h"
 
 #define LOCTEXT_NAMESPACE "AssetTypeActions_GaussianSplatAsset"

--- a/Plugins/NanoGS/Source/NanoGSEditor/Private/GaussianSplatThumbnailRenderer.cpp
+++ b/Plugins/NanoGS/Source/NanoGSEditor/Private/GaussianSplatThumbnailRenderer.cpp
@@ -5,6 +5,7 @@
 #include "CanvasItem.h"
 #include "Engine/Canvas.h"
 #include "Engine/Texture2D.h"
+#include "TextureResource.h"
 
 void UGaussianSplatThumbnailRenderer::Draw(
 	UObject* Object,
@@ -27,7 +28,7 @@ void UGaussianSplatThumbnailRenderer::Draw(
 		Thumb->UpdateResource();
 	}
 
-	FTexture* TextureResource = Thumb->GetResource();
+	FTextureResource* TextureResource = Thumb->GetResource();
 	if (!TextureResource) return;
 
 	FCanvasTileItem TileItem(


### PR DESCRIPTION
This PR fixes compile compatibility with Unreal Engine 5.8.\n\nChanges:\n- Add explicit includes required by UE 5.8's stricter include behavior.\n- Use FTextureResource for thumbnail rendering.\n- Guard UTexture2D::MipGenSettings with WITH_EDITORONLY_DATA for non-editor targets.\n\nVerified with UE 5.8:\n\\\\nRunUAT BuildPlugin -Plugin=.../NanoGS.uplugin -Package=.../NanoGS_UE58_Package -TargetPlatforms=Win64\n\\\\n\nTargets passed:\n- UnrealEditor Win64 Development\n- UnrealGame Win64 Development\n- UnrealGame Win64 Shipping