### PR TITLE
1.AI（claude code）自己审查并优化，测试性能提高非常多，可以流畅使用。

### DIFF
--- a/Plugins/NanoGS/Shaders/Private/CalcViewData.usf
+++ b/Plugins/NanoGS/Shaders/Private/CalcViewData.usf
@@ -122,7 +122,8 @@ void ProcessSplat(uint splatIndex, uint outputIndex, uint selectedClusterID, uin
 	// Calculate covariance
 	float3x3 cov3D_local = CalcCovariance3D(rotation, scale);
 	float3x3 localToWorldRot = (float3x3)LocalToWorld;
-	float3x3 cov3D_world = mul(transpose(localToWorldRot), mul(cov3D_local, localToWorldRot));
+	// Correct formula: R * Σ * R^T (HLSL row-major: mul(R, mul(Σ, transpose(R))))
+	float3x3 cov3D_world = mul(localToWorldRot, mul(cov3D_local, transpose(localToWorldRot)));
 	float3x3 viewMat = (float3x3)WorldToView;
 	float2x2 cov2D = CalcCovariance2D(cov3D_world, viewMat, viewPos.xyz, FocalLength);
 

--- a/Plugins/NanoGS/Source/NanoGS/Private/GaussianSplatAsset.cpp
+++ b/Plugins/NanoGS/Source/NanoGS/Private/GaussianSplatAsset.cpp
@@ -544,9 +544,17 @@ void UGaussianSplatAsset::GetPositionData(TArray<uint8>& OutData) const
 	const int64 DataSize = PositionBulkData.GetBulkDataSize();
 	if (DataSize > 0)
 	{
-		OutData.SetNum(static_cast<int32>(DataSize));
 		const void* SrcData = PositionBulkData.LockReadOnly();
-		FMemory::Memcpy(OutData.GetData(), SrcData, DataSize);
+		if (SrcData)
+		{
+			OutData.SetNum(static_cast<int32>(DataSize));
+			FMemory::Memcpy(OutData.GetData(), SrcData, DataSize);
+		}
+		else
+		{
+			UE_LOG(LogTemp, Warning, TEXT("GetPositionData: BulkData not resident for asset '%s'"), *GetName());
+			OutData.Empty();
+		}
 		PositionBulkData.Unlock();
 	}
 	else
@@ -560,9 +568,17 @@ void UGaussianSplatAsset::GetOtherData(TArray<uint8>& OutData) const
 	const int64 DataSize = OtherBulkData.GetBulkDataSize();
 	if (DataSize > 0)
 	{
-		OutData.SetNum(static_cast<int32>(DataSize));
 		const void* SrcData = OtherBulkData.LockReadOnly();
-		FMemory::Memcpy(OutData.GetData(), SrcData, DataSize);
+		if (SrcData)
+		{
+			OutData.SetNum(static_cast<int32>(DataSize));
+			FMemory::Memcpy(OutData.GetData(), SrcData, DataSize);
+		}
+		else
+		{
+			UE_LOG(LogTemp, Warning, TEXT("GetOtherData: BulkData not resident for asset '%s'"), *GetName());
+			OutData.Empty();
+		}
 		OtherBulkData.Unlock();
 	}
 	else
@@ -576,9 +592,17 @@ void UGaussianSplatAsset::GetSHData(TArray<uint8>& OutData) const
 	const int64 DataSize = SHBulkData.GetBulkDataSize();
 	if (DataSize > 0)
 	{
-		OutData.SetNum(static_cast<int32>(DataSize));
 		const void* SrcData = SHBulkData.LockReadOnly();
-		FMemory::Memcpy(OutData.GetData(), SrcData, DataSize);
+		if (SrcData)
+		{
+			OutData.SetNum(static_cast<int32>(DataSize));
+			FMemory::Memcpy(OutData.GetData(), SrcData, DataSize);
+		}
+		else
+		{
+			UE_LOG(LogTemp, Warning, TEXT("GetSHData: BulkData not resident for asset '%s'"), *GetName());
+			OutData.Empty();
+		}
 		SHBulkData.Unlock();
 	}
 	else
@@ -592,9 +616,17 @@ void UGaussianSplatAsset::GetColorTextureData(TArray<uint8>& OutData) const
 	const int64 DataSize = ColorTextureBulkData.GetBulkDataSize();
 	if (DataSize > 0)
 	{
-		OutData.SetNum(static_cast<int32>(DataSize));
 		const void* SrcData = ColorTextureBulkData.LockReadOnly();
-		FMemory::Memcpy(OutData.GetData(), SrcData, DataSize);
+		if (SrcData)
+		{
+			OutData.SetNum(static_cast<int32>(DataSize));
+			FMemory::Memcpy(OutData.GetData(), SrcData, DataSize);
+		}
+		else
+		{
+			UE_LOG(LogTemp, Warning, TEXT("GetColorTextureData: BulkData not resident for asset '%s'"), *GetName());
+			OutData.Empty();
+		}
 		ColorTextureBulkData.Unlock();
 	}
 	else

--- a/Plugins/NanoGS/Source/NanoGS/Private/GaussianSplatComponent.cpp
+++ b/Plugins/NanoGS/Source/NanoGS/Private/GaussianSplatComponent.cpp
@@ -86,6 +86,19 @@ FPrimitiveSceneProxy* UGaussianSplatComponent::CreateSceneProxy()
 		}
 	}
 
+	// Ensure ColorTexture RHI resource exists before the render thread touches it.
+	// UpdateResource() is game-thread-only; calling it here avoids the thread-safety
+	// violation that would occur inside CreateRenderThreadResources.
+	if (SplatAsset->ColorTexture)
+	{
+		FTexturePlatformData* PlatformData = SplatAsset->ColorTexture->GetPlatformData();
+		if (!SplatAsset->ColorTexture->GetResource() && PlatformData && PlatformData->Mips.Num() > 0
+			&& PlatformData->Mips[0].BulkData.GetBulkDataSize() > 0)
+		{
+			SplatAsset->ColorTexture->UpdateResource();
+		}
+	}
+
 	return new FGaussianSplatSceneProxy(this);
 }
 

--- a/Plugins/NanoGS/Source/NanoGS/Private/GaussianSplatRenderData.cpp
+++ b/Plugins/NanoGS/Source/NanoGS/Private/GaussianSplatRenderData.cpp
@@ -335,7 +335,16 @@ void FGaussianSplatRenderData::CreateGPUBuffers(FRHICommandListBase& RHICmdList)
 		SharedBufferCount++;
 	}
 
-	// Free CPU-side cached data after GPU upload
+	// Verify all critical buffers were created before discarding CPU data.
+	// CreateBuffer can silently return null on OOM or device-lost; if any required
+	// buffer is missing we cannot render, so keep CPU data intact for a potential retry.
+	if (!PackedSplatBuffer.IsValid() || !SHBuffer.IsValid())
+	{
+		UE_LOG(LogTemp, Error, TEXT("GaussianSplatRenderData: One or more GPU buffers failed to allocate for '%s'. Keeping CPU data."), *AssetName);
+		return;
+	}
+
+	// Free CPU-side cached data after successful GPU upload
 	PackedSplatData.Empty();
 	SHData.Empty();
 	CachedChunkData.Empty();

--- a/Plugins/NanoGS/Source/NanoGS/Private/GaussianSplatRenderer.cpp
+++ b/Plugins/NanoGS/Source/NanoGS/Private/GaussianSplatRenderer.cpp
@@ -536,7 +536,8 @@ void FGaussianSplatRenderer::DrawSplats(
 	FRHICommandListImmediate& RHICmdList,
 	const FSceneView& View,
 	FGaussianSplatGPUResources* GPUResources,
-	int32 SplatCount)
+	int32 SplatCount,
+	FGaussianGlobalAccumulator* VelocityAccumulator)
 {
 	SCOPED_DRAW_EVENT(RHICmdList, GaussianSplatDraw);
 
@@ -625,7 +626,7 @@ void FGaussianSplatRenderer::DrawSplats(
 
 	// Pixel shader parameters
 	FGaussianSplatPS::FParameters PSParameters;
-	SetVelocityPSParameters(PSParameters, View, nullptr);
+	SetVelocityPSParameters(PSParameters, View, VelocityAccumulator);
 	SetShaderParameters(RHICmdList, PixelShader, PixelShader.GetPixelShader(), PSParameters);
 
 	// Draw instanced quads
@@ -683,7 +684,10 @@ void FGaussianSplatRenderer::DispatchCompactSplats(
 		return;
 	}
 
-	// Reset visible splat count to 0
+	// Reset visible splat count to 0.
+	// Transition to CopySrc (CPU-writable staging state) before locking, then
+	// immediately transition back so the subsequent UAVCompute transition is coherent.
+	RHICmdList.Transition(FRHITransitionInfo(GPUResources->VisibleSplatCountBuffer, ERHIAccess::Unknown, ERHIAccess::CopySrc));
 	uint32 Zero = 0;
 	void* Data = RHICmdList.LockBuffer(GPUResources->VisibleSplatCountBuffer, 0, sizeof(uint32), RLM_WriteOnly);
 	FMemory::Memcpy(Data, &Zero, sizeof(uint32));
@@ -911,8 +915,11 @@ void FGaussianSplatRenderer::DispatchCalcViewDataGlobal(
 		return;
 	}
 
-	// Transition global buffer to UAV for writing (Unknown covers both first-proxy and subsequent calls)
-	RHICmdList.Transition(FRHITransitionInfo(GlobalAccumulator->GlobalViewDataBuffer, ERHIAccess::Unknown, ERHIAccess::UAVCompute));
+	// Transition global buffer: first proxy uses Unknown (buffer may be fresh or from prior frame);
+	// subsequent proxies must use UAVCompute→UAVCompute to insert the required execution barrier
+	// so proxy N's writes are visible before proxy N+1 reads the same buffer region.
+	ERHIAccess SrcAccess = (GlobalBaseOffset == 0) ? ERHIAccess::Unknown : ERHIAccess::UAVCompute;
+	RHICmdList.Transition(FRHITransitionInfo(GlobalAccumulator->GlobalViewDataBuffer, SrcAccess, ERHIAccess::UAVCompute));
 
 	FGaussianSplatCalcViewDataCS::FParameters Parameters;
 	Parameters.PackedSplatBuffer = GPUResources->PackedSplatBufferSRV;
@@ -1363,7 +1370,8 @@ void FGaussianSplatRenderer::DispatchCalcViewDataCompactedGlobal(
 	}
 
 	// Transition global ViewData buffer to UAV (Unknown handles first proxy and subsequent proxies)
-	RHICmdList.Transition(FRHITransitionInfo(GlobalAccumulator->GlobalViewDataBuffer, ERHIAccess::Unknown, ERHIAccess::UAVCompute));
+	ERHIAccess CompactedSrcAccess = (ProxyIndex == 0) ? ERHIAccess::Unknown : ERHIAccess::UAVCompute;
+	RHICmdList.Transition(FRHITransitionInfo(GlobalAccumulator->GlobalViewDataBuffer, CompactedSrcAccess, ERHIAccess::UAVCompute));
 
 	FGaussianSplatCalcViewDataCS::FParameters Parameters;
 	Parameters.PackedSplatBuffer = GPUResources->PackedSplatBufferSRV;

--- a/Plugins/NanoGS/Source/NanoGS/Private/GaussianSplatSceneProxy.cpp
+++ b/Plugins/NanoGS/Source/NanoGS/Private/GaussianSplatSceneProxy.cpp
@@ -839,7 +839,8 @@ void FGaussianSplatSceneProxy::CreateRenderThreadResources(FRHICommandListBase& 
 
 			if (!TextureResource && PlatformData && BulkDataSize > 0)
 			{
-				CachedAsset->ColorTexture->UpdateResource();
+				// UpdateResource() must be called on the game thread (done in CreateSceneProxy).
+				// By the time we reach here the resource should already exist; if not, skip.
 				TextureResource = CachedAsset->ColorTexture->GetResource();
 			}
 
@@ -924,7 +925,8 @@ void FGaussianSplatSceneProxy::TryInitializeColorTexture(FRHICommandListBase& RH
 
 		if (PlatformData && BulkDataSize > 0)
 		{
-			CachedAsset->ColorTexture->UpdateResource();
+			// UpdateResource() is game-thread-only; it is called in CreateSceneProxy before
+			// this render-thread function runs, so the resource should exist by now.
 			TextureResource = CachedAsset->ColorTexture->GetResource();
 		}
 	}

--- a/Plugins/NanoGS/Source/NanoGS/Public/GaussianSplatRenderer.h
+++ b/Plugins/NanoGS/Source/NanoGS/Public/GaussianSplatRenderer.h
@@ -68,12 +68,14 @@ public:
 
 	/**
 	 * Draw the Gaussian splats
+	 * @param VelocityAccumulator Per-proxy accumulator for motion vector output (may be nullptr)
 	 */
 	static void DrawSplats(
 		FRHICommandListImmediate& RHICmdList,
 		const FSceneView& View,
 		FGaussianSplatGPUResources* GPUResources,
-		int32 SplatCount
+		int32 SplatCount,
+		FGaussianGlobalAccumulator* VelocityAccumulator = nullptr
 	);
 
 	/**

--- a/Plugins/NanoGS/Source/NanoGS/Public/GaussianSplatSceneProxy.h
+++ b/Plugins/NanoGS/Source/NanoGS/Public/GaussianSplatSceneProxy.h
@@ -6,6 +6,7 @@
 #include "PrimitiveSceneProxy.h"
 #include "GaussianDataTypes.h"
 #include "GaussianClusterTypes.h"
+#include "GaussianGlobalAccumulator.h"
 #include "RenderResource.h"
 #include "RHI.h"
 #include "RHIResources.h"
@@ -332,6 +333,10 @@ public:
 	int32 CachedDebugMode = -1;
 	int32 CachedDebugForceLODLevel = -1;
 	bool bHasCachedSortData = false;
+
+	/** Per-proxy velocity accumulator for the non-global (single-proxy) render path.
+	 *  Stores previous frame VP matrices per view so DrawSplats can output correct motion vectors. */
+	FGaussianGlobalAccumulator VelocityAccumulator;
 };
 
 /**


### PR DESCRIPTION
严重 Bug（必须修）

协方差变换方向反了 CalcViewData.usf:125
实现的是 R^T·Σ·R，正确是 R·Σ·R^T。带旋转的 actor 所有 splat 形状都是错的，修复一行 mul 顺序即可。

Velocity 输出恒为零 GaussianSplatRenderer.cpp:628
非全局路径 DrawSplats 传 nullptr 给 SetVelocityPSParameters，导致前帧矩阵永不写入，motion vector 全帧为零，TAA/TSR/Motion Blur 全失效。

多 Proxy 全局缓冲区 UAV barrier 缺失 GaussianSplatRenderer.cpp:915 per-proxy 循环每次用 Unknown→UAVCompute，驱动层可能省略 barrier，Proxy N 写入对 N+1 不可见，多模型场景随机闪烁。

渲染线程调用游戏线程 API GaussianSplatSceneProxy.cpp:842
UpdateResource() 在 CreateRenderThreadResources 里调用，轻则纹理永久黑屏，重则 Debug 构建直接 check 崩溃。

VisibleSplatCountBuffer 状态转换缺失 GaussianSplatRenderer.cpp:688 LockBuffer 前未将 buffer 从 SRVCompute 转换到可写状态，D3D12/Vulkan 验证层每帧报错，GPU 可能读到 stale 数值。

性能瓶颈

Radix Sort O(256²) 复杂度 RadixSort.usf:273 ScatterCS 的 intra-pass rank 是串行线性扫描，百万 splat 场景下 sort 每帧耗时比标准实现高 10~50 倍，是最大的性能单点。换成 LDS prefix-sum 方案即可解决。 潜在崩溃（条件触发）

GPU buffer 创建失败后 CPU 数据被清空 GaussianSplatRenderData.cpp:339 任意一个 CreateBuffer 静默返回 null 后，函数仍清空所有 CPU 数据并置 bGPUBuffersCreated=true，之后无法恢复。

BulkData LockReadOnly 返回值未检查 GaussianSplatAsset.cpp:548 异步流送场景下 LockReadOnly() 可返回 nullptr，后续 Memcpy 立即崩溃。